### PR TITLE
Update Mongoose Promise Library

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ require('dotenv').load();
 require('./app/config/passport')(passport);
 
 mongoose.connect(process.env.MONGO_URI);
+mongoose.Promise = global.Promise;
 
 app.use('/controllers', express.static(process.cwd() + '/app/controllers'));
 app.use('/public', express.static(process.cwd() + '/public'));


### PR DESCRIPTION
I recently found clementine.js and cloned this repo to get started.  When I logged in to my application, I got a depreciation warning from Mongoose that said:

```
Mongoose: mpromise (mongoose's default promise library) is deprecated, 
plug in your own promise library instead: http://mongoosejs.com/docs/promises.html
```

The change that I've introduced is switching to using native ES6 promises with mongoose instead of the mpromise library.
